### PR TITLE
Alternatives error in first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 # Linux Java JDK Installer
 
-Based on the [askubuntu.com posting](https://askubuntu.com/questions/56104/how-can-i-install-sun-oracles-proprietary-java-jdk-6-7-8-or-jre), I created a Bash script to install either OpenJDK or Oracle Java JDK version 9 or higher in Debian Linux.  The script does not download the JDK, at least not in this release. The idea behind it was to provide greater control on what version of the JDK is installed as well as greater security by not relying on PPAs.  It is, therefore, up to the user to download the correct bit version of the JDK from a reliable source, like [OpenJDK](http://openjdk.java.net/) or [Oracle](https://www.oracle.com/technetwork/java/index.html).
+Based on the [askubuntu.com posting](https://askubuntu.com/questions/56104/how-can-i-install-sun-oracles-proprietary-java-jdk-6-7-8-or-jre), I created a Bash script to install either an Oracle OpenJDK or Oracle JDK version 9 or higher in Debian Linux.  The script does not download the JDK, at least not in this release. What started as a way to provide greater control on what JDK version to install, without relying PPAs, has morphed into the ablity to install multiple JDKs from different sources.  Therefore, it is up to the user to download the correct bit version of the JDK from a reliable source, like [OpenJDK](http://openjdk.java.net/) or [Oracle](https://www.oracle.com/technetwork/java/index.html).
 
-The script does not support installing JDK 8 since it's end of life is right around the corner, January 2019.
+The script does not support installing JDK 8 since it's end of life was January 2019.
 
 It was tested in Ubuntu 18.04 LTS.
 
@@ -23,15 +23,15 @@ Executing it with no parameters, or `-h`, or `-help` will print the help.
 
 The script performs the following:  
 
-1. **Validate Parameters**: based in the name, it will determine and inform you whether you're installing an Oracle provided OpenJDK or Oracle JDK.  It will then confirm the provided SHA256 sum value matches that for the provided JDK `tar` file.
+1. **Validate Parameters**: based on the name, it will determine and inform you whether you're installing an Oracle provided OpenJDK or Oracle JDK.  It will then confirm the provided SHA256 sum value matches that of the provided JDK `tar` file.
 
 2. **Extract JDK File**: extracts the provided JDK `tar`, and confirm, based on naming convention, whether the extracted folder is a JDK folder.
 
-3. **Check if JDK is Already Installed**: The scripts checks if there is a JDK installed by running `javac -version`.  If it successfully runs, it then checks how the installed JDK was configured by looking up the system's alternatives.  The script will only installed the specified JDK if there is no JDK installed or if the current one was configured through alternatives.
+3. **Check if JDK is Already Installed**: The scripts checks if there is a JDK installed by running `javac -version` under the current user.  If it successfully runs, it then checks how the installed JDK was configured by looking up the system's alternatives.  The script will only install the specified JDK if there is no JDK installed or if the current one was configured through alternatives.
 
 4. **Removes Previous Versions**: the script will remove the JDK it previously installed.  This step also includes removing configuration settings done through `update-alternatives`.
 
-5. **Move Extracted JDK to Folder**: moves the extracted JDK to `/usr/lib/jvm/jdk-*`.  For example if installing JDK 10, the folder will be `/usr/lib/jvm/jdk-10`.
+5. **Move Extracted JDK to System Folder**: moves the extracted JDK to `/usr/lib/jvm/jdk-*`.  For example if installing JDK 10, the folder will be `/usr/lib/jvm/jdk-10`.
 
 6. **Configure JDK Programs**: configure the following programs using `update-alternatives`:
 
@@ -57,11 +57,11 @@ The script does not setup Java to run in FireFox.  This was done intentionally s
 
 Time permitting, looking to add the following functionality:
 
-* Add support to install OpenJDKs from [AdoptOpenJDK](https://adoptopenjdk.net/) and [Azul Systems](https://www.azul.com/downloads/zulu-community/?architecture=x86-64-bit&package=jdk).  Now a days, there are more JDK providers the just Oracle.
+* Add support to install OpenJDKs from [AdoptOpenJDK](https://adoptopenjdk.net/) and [Azul Systems](https://www.azul.com/downloads/zulu-community/?architecture=x86-64-bit&package=jdk).  Now a days there are more JDK providers than just Oracle.
 
 * Provide the ability to install a JDK without removing the current one.  Handy feature that will allow to install more than one JDK in order to evaluate it while still coding for a previous version.
 
-* Install JDK but do not configure it to be the active version.  Goes hand-in-hand with the previous enhancement.  Again, install the latest or an early access to play with it, but do not change the system configurations to point to it.
+* Install a JDK but do not configure it to be the active version.  Goes hand-in-hand with the previous enhancement.  Again, install the latest or an early access to play with it, but do not change the system configurations to point to it.
 
 * Update system configurations to point to another JDK.  Still on the same theme... provide the ability to update system configurations to point to another installed JDK.  That means, for example, you can have version 14 and 15 installed, and easily switch configurations between one and the other.
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Executing it with no parameters, or `-h`, or `-help` will print the help.
 
 The script performs the following:  
 
-1. **Validate Parameters**: based in the name, it will determine and inform you whether you're installing an OpenJDK or Oracle JDK.  It will then confirm the provided SHA256 sum value matches that for the provided JDK `tar` file.
+1. **Validate Parameters**: based in the name, it will determine and inform you whether you're installing an Oracle provided OpenJDK or Oracle JDK.  It will then confirm the provided SHA256 sum value matches that for the provided JDK `tar` file.
 
 2. **Extract JDK File**: extracts the provided JDK `tar`, and confirm, based on naming convention, whether the extracted folder is a JDK folder.
 
-3. **Check if JDK is Already Installed**: script extracted JDK are installed in `/usr/lib/jvm/jdk-*` folder.  The scripts checks if there are any versions of JDK installed that meets this criteria.
+3. **Check if JDK is Already Installed**: The scripts checks if there is a JDK installed by running `javac -version`.  If it successfully runs, it then checks how the installed JDK was configured by looking up the system's alternatives.  The script will only installed the specified JDK if there is no JDK installed or if the current one was configured through alternatives.
 
-4. **Removes Previous Versions**: if there are any versions of the JDK installed, the script will remove them.  This step also includes removing any previously configured `update-alternatives`.
+4. **Removes Previous Versions**: the script will remove the JDK it previously installed.  This step also includes removing configuration settings done through `update-alternatives`.
 
 5. **Move Extracted JDK to Folder**: moves the extracted JDK to `/usr/lib/jvm/jdk-*`.  For example if installing JDK 10, the folder will be `/usr/lib/jvm/jdk-10`.
 
@@ -38,7 +38,6 @@ The script performs the following:
     * java
     * javac
     * jar
-    * javaws
     * javadoc
     * jshell
     * jlink
@@ -58,11 +57,15 @@ The script does not setup Java to run in FireFox.  This was done intentionally s
 
 Time permitting, looking to add the following functionality:
 
-* Download OpenJDK requested version.  Unlike Oracle, OpenJDK URLs are consistent and there is no requirement to accept a license agreement.  This feature will come in handy with the new Java cadence of six month releases.
+* Add support to install OpenJDKs from [AdoptOpenJDK](https://adoptopenjdk.net/) and [Azul Systems](https://www.azul.com/downloads/zulu-community/?architecture=x86-64-bit&package=jdk).  Now a days, there are more JDK providers the just Oracle.
 
-* Support to install multiple JDK versions.  On the same line, allow the ability switch between them.
+* Provide the ability to install a JDK without removing the current one.  Handy feature that will allow to install more than one JDK in order to evaluate it while still coding for a previous version.
 
-* Expand to other Linux versions.  Have the script create symbolic links in `/usr/bin` instead of using `update-alternatives`. 
+* Install JDK but do not configured to be the active version.  Goes hand-in-hand with the previous enhancement.  Again, install the latest or an early access to play with it, but do not change the system configurations to point to it.
+
+* Update system configurations to point to another JDK.  Still in the same theme... provide the ability to update system configurations to point to another installed JDK.  That means, for example, you can have version 14 and 15 installed, and easily switch configurations between one and the other.
+
+* Removed a specify JDK previously installed by the script.  This provide a clean way to remove an installed JDK that's no longer supported or just don't need.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Based on the [askubuntu.com posting](https://askubuntu.com/questions/56104/how-c
 
 The script does not support installing JDK 8 since it's end of life is right around the corner, January 2019.
 
-It was tested in Ubuntu 14.04 LTS and 16.04 LTS.
+It was tested in Ubuntu 18.04 LTS.
 
 ## Usage
 
@@ -61,7 +61,7 @@ Time permitting, looking to add the following functionality:
 
 * Provide the ability to install a JDK without removing the current one.  Handy feature that will allow to install more than one JDK in order to evaluate it while still coding for a previous version.
 
-* Install JDK but do not configured to be the active version.  Goes hand-in-hand with the previous enhancement.  Again, install the latest or an early access to play with it, but do not change the system configurations to point to it.
+* Install JDK but do not configure it to be the active version.  Goes hand-in-hand with the previous enhancement.  Again, install the latest or an early access to play with it, but do not change the system configurations to point to it.
 
 * Update system configurations to point to another JDK.  Still in the same theme... provide the ability to update system configurations to point to another installed JDK.  That means, for example, you can have version 14 and 15 installed, and easily switch configurations between one and the other.
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Time permitting, looking to add the following functionality:
 
 * Install JDK but do not configure it to be the active version.  Goes hand-in-hand with the previous enhancement.  Again, install the latest or an early access to play with it, but do not change the system configurations to point to it.
 
-* Update system configurations to point to another JDK.  Still in the same theme... provide the ability to update system configurations to point to another installed JDK.  That means, for example, you can have version 14 and 15 installed, and easily switch configurations between one and the other.
+* Update system configurations to point to another JDK.  Still on the same theme... provide the ability to update system configurations to point to another installed JDK.  That means, for example, you can have version 14 and 15 installed, and easily switch configurations between one and the other.
 
-* Removed a specify JDK previously installed by the script.  This provide a clean way to remove an installed JDK that's no longer supported or just don't need.
+* Removed a specific JDK previously installed by the script.  This provide a clean way to remove an installed JDK that's no longer supported or just don't need.
 
 ## License
 


### PR DESCRIPTION
Refactor logic to account for the following scenarios when installing the requested JDK:

- There is no JDK installed.
- There is a JDK not installed by the script and configured through the system path variable.
- There is a JDK and it was installed by the script.
- There are multiple JDKs, one installed by the script and another one by the user/program, that are configured through the system's alternatives and it's not pointing to the one installed by the script.

To that end, I made the following changes to the script:

- validateParams: added validation to confirm running user is root.
- isJDKInstalled: refactored entire logic.  The script will now check if a JDK is installed by getting the result of `javac -version` instead of `java -version`.  The latter may be a JRE.  In addition, the command is running under the user account account instead of root in order to account for changes to the system path.  Finally aside from notifying the user if there is a JDK and how it was installed, the function will, if the current JDK was setup through the path, perform a clean up and notify the user it cannot install the new JDK when there is a JDK setup outside of the system alternatives.
- Main: added logic to stop the script when there is a JDK installed but not configured through system alternatives.
- removeCurrentConfiguration: script will now only remove any previously configure settings it performed.  Before it was removing all `java` options which will break other programs.  Also removed logic for `javaws`, which is not supported in OpenJDK.  Finally, I updated output messages accordingly.
- configureJDKUtilities: remove logic to setup `javaws` as well as updated output messages accordingly.

Performed the following changes to the README.md:

- Updated introduction paragraph to reflect current functionality and new goals.
- Updated "What It Does?" section to reflect the new logic implemented in this release.
- Updated "Future" section to reflect the next feature enhancements, which are already submitted via issues.

Script version is 1.1.0.

Changes were tested in Ubuntu 18.04LTS.  Here are the test output runs:

[NoJDKInstalledTestRun.txt](https://github.com/jhenriquez418/linux-java-jdk-installer/files/4606795/NoJDKInstalledTestRun.txt)
[PreviouslyInstallByScriptJavaPointsToAnotherJDKTestRun.txt](https://github.com/jhenriquez418/linux-java-jdk-installer/files/4606796/PreviouslyInstallByScriptJavaPointsToAnotherJDKTestRun.txt)
[PreviouslyInstallByScriptTestRun.txt](https://github.com/jhenriquez418/linux-java-jdk-installer/files/4606797/PreviouslyInstallByScriptTestRun.txt)
[PreviouslyInstallViaPathTestRun.txt](https://github.com/jhenriquez418/linux-java-jdk-installer/files/4606798/PreviouslyInstallViaPathTestRun.txt)

This pull request closes issue #4.
