### PR TITLE
Support semeru tar gz install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Linux Java JDK Installer
 
-Based on the [askubuntu.com posting](https://askubuntu.com/questions/56104/how-can-i-install-sun-oracles-proprietary-java-jdk-6-7-8-or-jre), I created a Bash script to install either an [AdoptOpenJDK](https://adoptopenjdk.net/), [Azul Systems](https://www.azul.com/downloads/zulu-community/?architecture=x86-64-bit&package=jdk), or [Oracle](http://openjdk.java.net/) OpenJDK version 9 or higher in Debian Linux.  The script does not download the JDK, at least not in this release. What started as a way to provide greater control on what JDK version to install, without relying PPAs, has morphed into the ablity to install multiple JDKs from different sources.  Therefore, it is up to the user to download the correct bit version of the JDK from a reliable source.
+Based on the [askubuntu.com posting](https://askubuntu.com/questions/56104/how-can-i-install-sun-oracles-proprietary-java-jdk-6-7-8-or-jre), I created a Bash script to install either an [Adoptium](https://adoptium.net/), [Azul Systems](https://www.azul.com/downloads/zulu-community/?architecture=x86-64-bit&package=jdk), [IBM Semeru](https://developer.ibm.com/languages/java/semeru-runtimes/downloads) or [Oracle](http://openjdk.java.net/) OpenJDK version 9 or higher in Debian Linux.  The script does not download the JDK, at least not in this release. What started as a way to provide greater control on what JDK version to install, without relying PPAs, has morphed into the ablity to install multiple JDKs from different sources.  Therefore, it is up to the user to download the correct bit version of the JDK from a reliable source.
 
 The script does not support installing JDK 8 since it's end of life was originally January 2019.
 

--- a/installJavaJDK.sh
+++ b/installJavaJDK.sh
@@ -50,7 +50,7 @@ readonly IBM_SEMERU_FILE_FORMAT="ibm-semeru-open-jdk_x64_linux_([0-9]){2,}(\.[0-
 readonly ZULU_FILE_FORMAT="zulu([0-9]){1,3}(\.([0-9]){1,3}){2}-ca-jdk([0-9]){2,}(\.[0-9]){0,3}-linux_x64.tar.gz"
 readonly ORACLE_FILE_FORMAT="openjdk-([0-9]){2,}(\.[0-9]){0,3}_linux-x64_bin.tar.gz"
 
-readonly SCRIPT_VERSION="1.2.0"
+readonly SCRIPT_VERSION="1.3.0"
 
 # Global variables...
 processComand=-1


### PR DESCRIPTION
Here are the changes done to support IBM Semeru JDKs as well updates to Adoptium - the AdoptOpenJDK replacement:

1. replaced all references to AdoptOpenJDK to Adoptium in the script and read me files
2. updated read me file to include IBM Semeru support
3. added IBM Semeru JDK file regular expression to identify JDK files and logic to extract the version number
4. updated Adoptium JDK file regular expression to identify only HotSpot JVM since they will no longer supply Open J9

All changes were test in Ubuntu 18LTS.  Attached are the run logs for all supported versions.

[Adoptium.log](https://github.com/jhenriquez418/linux-java-jdk-installer/files/7741753/Adoptium.log)
[IBMSemeru.log](https://github.com/jhenriquez418/linux-java-jdk-installer/files/7741754/IBMSemeru.log)
[Oracle.log](https://github.com/jhenriquez418/linux-java-jdk-installer/files/7741755/Oracle.log)
[Zulu.log](https://github.com/jhenriquez418/linux-java-jdk-installer/files/7741756/Zulu.log)
